### PR TITLE
Outil IO slip pour python3 + exemple avec pyo

### DIFF
--- a/protocoles/serial/slip/python3/ProtoSLIP.py
+++ b/protocoles/serial/slip/python3/ProtoSLIP.py
@@ -1,0 +1,73 @@
+# modifié pour fonctionner avec python3
+# Code volé à  Asanka P. Sayakkara ici:
+# http://recolog.blogspot.ca/2012/10/serial-line-internet-protocol-slip.html
+
+import serial
+from collections import deque
+SLIP_END = 192          # Ces nombres sont en base 8 (octal)
+SLIP_ESC = 219          # En décimal, ils correspondent à: 192, 219, 220 et
+                         # 221
+SLIP_ESC_END = 220
+SLIP_ESC_ESC = 221
+DEBUG_MAKER = 13
+MAX_MTU = 200
+readBufferQueue = deque([])
+#-------------------------------------------------------------------------------
+# Cette fonction reçoit une liste d'octets (bytes) et les encode en SLIP.
+def encodeToSLIP(byteList):
+     tempSLIPBuffer = []
+     tempSLIPBuffer.append(SLIP_END)
+     for i in byteList:
+          if i == SLIP_END:
+               tempSLIPBuffer.append(SLIP_ESC)
+               tempSLIPBuffer.append(SLIP_ESC_END)
+          elif i == SLIP_ESC:
+               tempSLIPBuffer.append(SLIP_ESC)
+               tempSLIPBuffer.append(SLIP_ESC_ESC)
+          else:
+               tempSLIPBuffer.append(i)
+     tempSLIPBuffer.append(SLIP_END)
+     return tempSLIPBuffer
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Cette fonction utilise getSerialByte() pour obtenir des octets encodés en SLIP du port série.
+def decodeFromSLIP(serialFD):
+     dataBuffer = []
+     while 1:
+          serialByte = getSerialByte(serialFD)
+          if serialByte is None:
+               return -1
+          elif serialByte == SLIP_END:
+               if len(dataBuffer) > 0:
+                    return dataBuffer
+          elif serialByte == SLIP_ESC:
+               serialByte = getSerialByte(serialFD)
+               if serialByte is None:
+                    return -1
+               elif serialByte == SLIP_ESC_END:
+                    dataBuffer.append(SLIP_END)
+               elif serialByte == SLIP_ESC_ESC:
+                    dataBuffer.append(SLIP_ESC)
+               elif serialByte == DEBUG_MAKER:
+                    dataBuffer.append(DEBUG_MAKER)
+               else:
+                    print("Protocol Error")
+          else:
+               dataBuffer.append(serialByte)
+     return
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Cette fonction lit les données sur le port série et retourne un octet à la fois.
+def getSerialByte(serialFD):
+     if len(readBufferQueue) == 0:
+          #fetch a new data chunk from the serial port
+          i = 0
+          while len(readBufferQueue) < MAX_MTU:
+               newByte = ord(serialFD.read())
+               readBufferQueue.append(newByte)
+          newByte = readBufferQueue.popleft()
+          return newByte
+     else:
+          newByte = readBufferQueue.popleft()
+          return newByte
+#-------------------------------------------------------------------------------

--- a/protocoles/serial/slip/python3/SerialComm.py
+++ b/protocoles/serial/slip/python3/SerialComm.py
@@ -1,0 +1,49 @@
+# modifié pour fonctionner avec python3
+# Code stolen from Asanka P. Sayakkara here:
+# Code volé à Asanka P. Sayakkara ici:
+# http://recolog.blogspot.ca/2012/10/serial-line-internet-protocol-slip.html
+
+import ProtoSLIP
+import serial
+#-------------------------------------------------------------------------------
+# Cette fonction ouvre le port série et retourne un objet FileDescriptor qui représente ce port.
+def connectToSerialPort(port='/dev/ttyUSB0', baudrate=115200):
+     serialFD = serial.Serial(
+          port, baudrate,
+          bytesize=8, parity='N', stopbits=1, xonxoff=False, rtscts=False
+          )
+     # port='/dev/ttyUSB0'- nom du port
+     # baudrate=115200  - baud rate
+     # bytesize=8           - size of a byte
+     # parity='N'           - no parity
+     # stopbits=1           - 1 stop bit
+     # xonxoff=False           - no software handshakes
+     # rtscts=False           - no hardware handshakes
+     return serialFD
+#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
+# Cette fonction prend un array d'octets (bytes) et les écrit sur le port
+# série en utilisant le protocol SLIP.
+def writeToSerialPort(serialFD, byteArray):
+     encodedSLIPBytes = ProtoSLIP.encodeToSLIP(byteArray)
+     byteString = bytes(encodedSLIPBytes) #convert byte list to a string
+     serialFD.write(byteString)
+     return
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Cette fonction lit le port série et retourne un array de bytes.
+def readFromSerialPort(serialFD):
+     i = 1
+     byteArray = None
+     byteArray = ProtoSLIP.decodeFromSLIP(serialFD)
+     if byteArray is None:
+          return -1
+     else:
+          return byteArray
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Cette fonction ferme le port série
+def disconnectFromSerialPort(serialFD):
+     serialFD.close()
+     return
+#-------------------------------------------------------------------------------

--- a/protocoles/serial/slip/python3/pyo_serial_tools.py
+++ b/protocoles/serial/slip/python3/pyo_serial_tools.py
@@ -1,0 +1,38 @@
+# code pris en grande partie de mus3328-exemples/protocoles/serial/slip/python/SLIPinOut.py et modifié pour fonctionner en python3
+import SerialComm
+import ProtoSLIP
+import threading
+import time
+
+class SLIPIO:
+    """
+    Cette classe lit des packets SLIP contenant une quantité arbitraire de valeurs sur 16 bits et appelle une fonction callback à chaque packets lus.
+    la fonction callback reçoit deux arguments : values et une fonction d'écriture sur le port série pouvant être appellée avec une liste (ou itérable) contenant des valeurs entières entre 0 et 255
+    voir testpyoserial.py pour un apperçu de l'utilisation de cette classe
+    """
+    def __init__(self, port_name, baud_rate, callback, sleep_time=0.002):
+        # 0.002 est un chiffre arbitraire, vous pouvez le modifier si vous avez des problèmes de performance
+        self.sleep_time = 0.002
+        self.port_name = port_name
+        self.baud_rate = baud_rate
+        self.serial_port = SerialComm.connectToSerialPort(port_name, baud_rate)
+        self.callback = callback
+        self.thread = None
+
+    def _loop(self):
+        while (True):
+            bytes = ProtoSLIP.decodeFromSLIP(self.serial_port)
+            values = []
+            if len(bytes) >= 2:
+                for i in range(0, len(bytes), 2):
+                    values.append(bytes[i]<<8 | bytes[i+1])
+                self.callback(values, lambda x: SerialComm.writeToSerialPort(self.serial_port, x))
+            time.sleep(self.sleep_time)
+        self.serial_port.flush()
+        SerialComm.disconnectFromSerialPort(self.serial_port)
+        return
+
+    def start(self):
+        self.thread = threading.Thread(target=lambda : self._loop())
+        self.thread.daemon = True
+        self.thread.start()

--- a/protocoles/serial/slip/python3/testpyoserial.py
+++ b/protocoles/serial/slip/python3/testpyoserial.py
@@ -1,0 +1,33 @@
+# exemple d'utilisation de slip avec pyo en python3
+
+from pyo_serial_tools import SLIPIO
+from pyo import *
+
+s = Server().boot()
+
+# sig avec interpolation de pyo avec un buffer de 3 valeurs (à augmenter si vous avez plus de seunseurs)
+sig = SigTo([0]*3)
+
+
+def slipcallback(vals, write_to_serial):
+    """
+    fonction qui sera appelée à chaque paque slip reçu par le programme.
+    vals: valeurs en entiers 16 bits reçues
+    write_to_serial: est une fonction permettant d'écrire une liste de valeurs entre 0 et 255 sur le port série par le protocole slip
+    """
+    # change les valeurs du SigTo pour les nouvelles valeurs de senseur lues
+    sig.value = vals
+    # réécrit les valeurs reçues en les shiftant sur 8 bits
+    write_to_serial([val>>2 for val in vals])
+
+# création du receveur de packets slips en lui passant l'emplacement du port série, le baud rate et le callback
+slip_receiver = SLIPIO(port_name="/dev/ttyACM0", baud_rate=115200, callback=slipcallback)
+
+slip_receiver.start()
+
+# controle de la fréquence d'oscillateurs avec nos données de senseur
+sound = LFO(freq=sig,  mul=0.3)
+sound.out()
+
+s.start()
+s.gui(locals)


### PR DESCRIPTION
Ce pull request contient les deux modules ProtoSLIP et SerialComm légèrement modifiés pour fonctionner avec python3 ainsi qu'une classe facilitant l'utilisation de ces modules et un exemple d'interaction avec pyo.